### PR TITLE
Abhay/misc

### DIFF
--- a/safetytooling/apis/inference/cache_manager.py
+++ b/safetytooling/apis/inference/cache_manager.py
@@ -66,8 +66,8 @@ class CacheManager:
         empty_completion_threshold: float = 0.5,  # If we have multiple responses in a cache, threshold proportion of them that can be empty before we run retries
     ) -> Tuple[
         List[LLMResponse | List[LLMResponse] | None],
-        List[[LLMCache | None]],
-        [List[LLMResponse | List[LLMResponse] | None]],
+        List[LLMCache | None],
+        List[LLMResponse | List[LLMResponse] | None]
     ]:
         """
         Process cached responses for a given prompt or batch of prompts.

--- a/safetytooling/apis/inference/cache_manager.py
+++ b/safetytooling/apis/inference/cache_manager.py
@@ -67,7 +67,7 @@ class CacheManager:
     ) -> Tuple[
         List[LLMResponse | List[LLMResponse] | None],
         List[LLMCache | None],
-        List[LLMResponse | List[LLMResponse] | None]
+        List[LLMResponse | List[LLMResponse] | None],
     ]:
         """
         Process cached responses for a given prompt or batch of prompts.

--- a/safetytooling/apis/inference/huggingface.py
+++ b/safetytooling/apis/inference/huggingface.py
@@ -215,12 +215,18 @@ class HuggingFaceModel(InferenceAPIModel):
         response = LLMResponse(
             model_id=model_id,
             completion=response_data[0]["generated_text"],
-            stop_reason=("eos" if "details" not in response_data[0] 
-                        else self.stop_reason_map[response_data[0]["details"]["finish_reason"]]),
+            stop_reason=(
+                "eos"
+                if "details" not in response_data[0]
+                else self.stop_reason_map[response_data[0]["details"]["finish_reason"]]
+            ),
             duration=duration,
             api_duration=api_duration,
-            logprobs=(None if "details" not in response_data[0] 
-                    else self.parse_logprobs(response_details=response_data[0]["details"])),
+            logprobs=(
+                None
+                if "details" not in response_data[0]
+                else self.parse_logprobs(response_details=response_data[0]["details"])
+            ),
             cost=0,
         )
         responses = [response]

--- a/safetytooling/apis/inference/huggingface.py
+++ b/safetytooling/apis/inference/huggingface.py
@@ -215,10 +215,12 @@ class HuggingFaceModel(InferenceAPIModel):
         response = LLMResponse(
             model_id=model_id,
             completion=response_data[0]["generated_text"],
-            stop_reason=self.stop_reason_map[response_data[0]["details"]["finish_reason"]],
+            stop_reason=("eos" if "details" not in response_data[0] 
+                        else self.stop_reason_map[response_data[0]["details"]["finish_reason"]]),
             duration=duration,
             api_duration=api_duration,
-            logprobs=self.parse_logprobs(response_details=response_data[0]["details"]),
+            logprobs=(None if "details" not in response_data[0] 
+                    else self.parse_logprobs(response_details=response_data[0]["details"])),
             cost=0,
         )
         responses = [response]

--- a/safetytooling/apis/inference/huggingface.py
+++ b/safetytooling/apis/inference/huggingface.py
@@ -216,7 +216,7 @@ class HuggingFaceModel(InferenceAPIModel):
             model_id=model_id,
             completion=response_data[0]["generated_text"],
             stop_reason=(
-                "eos"
+                StopReason.UNKNOWN.value
                 if "details" not in response_data[0]
                 else self.stop_reason_map[response_data[0]["details"]["finish_reason"]]
             ),

--- a/safetytooling/data_models/inference.py
+++ b/safetytooling/data_models/inference.py
@@ -33,6 +33,7 @@ class StopReason(Enum):
     CONTENT_FILTER = "content_filter"
     API_ERROR = "api_error"
     PROMPT_BLOCKED = "prompt_blocked"
+    UNKNOWN = "unknown"
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
Two changes
- Modify the typing on process_cached_responses such that it does not throw an error in python versions before 3.11
- Modify huggingface inference API so that have a default value for stop reason/logprobs in the case that "details" is not present.