### PR TITLE
Added support for o1-2024-12-17 and structured outputs

### DIFF
--- a/safetytooling/apis/inference/api.py
+++ b/safetytooling/apis/inference/api.py
@@ -369,8 +369,7 @@ class InferenceAPI:
                 Passing in multiple models could speed up the response time if one of the models is overloaded.
             prompt: The prompt to send to the model(s). Type should be Prompt.
             audio_out_dir : The directory where any audio output from the model (relevant for speech-to-speech models) should be saved
-            max_tokens: The maximum number of tokens to request from the API (argument added to
-                standardize the Anthropic and OpenAI APIs, which have different names for this).
+            max_tokens: The maximum number of tokens to request from the API. For o1 models this is used as max_completion_tokens.
             print_prompt_and_response: Whether to print the prompt and response to stdout.
             n: The number of completions to request.
             max_attempts_per_api_call: Passed to the underlying API call. If the API call fails (e.g. because the
@@ -406,8 +405,11 @@ class InferenceAPI:
         if isinstance(model_class, AnthropicChatModel):
             max_tokens = max_tokens if max_tokens is not None else 2000
             kwargs["max_tokens"] = max_tokens
-        else:
-            if max_tokens is not None:
+        elif max_tokens is not None:
+            if any(model_id.startswith("o1") for model_id in model_ids):
+                # o1 models use max_completion_tokens instead of max_tokens
+                kwargs["max_completion_tokens"] = max_tokens
+            else:
                 kwargs["max_tokens"] = max_tokens
 
         num_candidates = num_candidates_per_completion * n

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -6,6 +6,7 @@ import time
 import openai
 import openai.types
 import openai.types.chat
+import pydantic
 import requests
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -99,7 +100,16 @@ class OpenAIChatModel(OpenAIModel):
 
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
         api_start = time.time()
-        api_response: openai.types.chat.ChatCompletion = await self.aclient.chat.completions.create(
+
+        # Choose between parse and create based on response format
+        if ('response_format' in params and 
+            isinstance(params['response_format'], type) and 
+            issubclass(params['response_format'], pydantic.BaseModel)):
+            api_func = self.aclient.beta.chat.completions.parse
+            LOGGER.info(f"Using parse API because response_format: {params['response_format']} is of type {type(params['response_format'])}")
+        else:
+            api_func = self.aclient.chat.completions.create
+        api_response: openai.types.chat.ChatCompletion = await api_func(
             messages=prompt.openai_format(),
             model=model_id,
             **params,

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -102,11 +102,15 @@ class OpenAIChatModel(OpenAIModel):
         api_start = time.time()
 
         # Choose between parse and create based on response format
-        if ('response_format' in params and 
-            isinstance(params['response_format'], type) and 
-            issubclass(params['response_format'], pydantic.BaseModel)):
+        if (
+            "response_format" in params
+            and isinstance(params["response_format"], type)
+            and issubclass(params["response_format"], pydantic.BaseModel)
+        ):
             api_func = self.aclient.beta.chat.completions.parse
-            LOGGER.info(f"Using parse API because response_format: {params['response_format']} is of type {type(params['response_format'])}")
+            LOGGER.info(
+                f"Using parse API because response_format: {params['response_format']} is of type {type(params['response_format'])}"
+            )
         else:
             api_func = self.aclient.chat.completions.create
         api_response: openai.types.chat.ChatCompletion = await api_func(

--- a/safetytooling/apis/inference/openai/utils.py
+++ b/safetytooling/apis/inference/openai/utils.py
@@ -29,7 +29,8 @@ _GPT_4_MODELS = (
     "o1-mini-2024-09-12",
     "o1-preview",
     "o1-preview-2024-09-12",
-    # Models older than 2024-12-17 do not support structured outputs
+    # THese o1 models support structured outputs https://platform.openai.com/docs/guides/structured-outputs#supported-models
+    "o1",
     "o1-2024-12-17",
     "gpt-4o-mini",
     "gpt-4o-mini-2024-07-18",

--- a/safetytooling/apis/inference/openai/utils.py
+++ b/safetytooling/apis/inference/openai/utils.py
@@ -29,6 +29,8 @@ _GPT_4_MODELS = (
     "o1-mini-2024-09-12",
     "o1-preview",
     "o1-preview-2024-09-12",
+    # Models older than 2024-12-17 do not support structured outputs
+    "o1-2024-12-17",
     "gpt-4o-mini",
     "gpt-4o-mini-2024-07-18",
     "gpt-4o",
@@ -173,6 +175,7 @@ def price_per_token(model_id: str) -> tuple[float, float]:
         "o1-mini-2024-09-12",
         "o1-preview",
         "o1-preview-2024-09-12",
+        "o1-2024-12-17",
     ):
         prices = 0, 0
     elif model_id in (

--- a/safetytooling/data_models/inference.py
+++ b/safetytooling/data_models/inference.py
@@ -30,7 +30,7 @@ class LLMParams(HashableBaseModel):
         # Currently we send a pydantic.BaseModel class type in this param, which is not serializable.
         # Caching will be agnostic to the value of this field
         # Remove exlude=True once you figure out how to serialise pydantic.BaseModel class types
-        exclude=True
+        exclude=True,
     )
     model_config = pydantic.ConfigDict(extra="forbid")
 

--- a/safetytooling/data_models/inference.py
+++ b/safetytooling/data_models/inference.py
@@ -17,8 +17,8 @@ class LLMParams(HashableBaseModel):
     n: int = 1
     num_candidates_per_completion: int = 1
     insufficient_valids_behaviour: Literal["error", "continue", "pad_invalids", "retry"] = "retry"
-    max_tokens: int | None = None  # For o1 models this is converted to max_completion_tokens in the API layer
-    max_completion_tokens: int | None = None  # Used by o1 models
+    max_tokens: int | None = None  # For OpenAI models this is converted to max_completion_tokens in the API layer
+    max_completion_tokens: int | None = None  # Used by OpenAI models
     logprobs: int | None = None
     seed: int | None = None
     return_logprobs: bool = False  # ?

--- a/safetytooling/data_models/inference.py
+++ b/safetytooling/data_models/inference.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 import openai
 import pydantic
@@ -17,13 +17,21 @@ class LLMParams(HashableBaseModel):
     n: int = 1
     num_candidates_per_completion: int = 1
     insufficient_valids_behaviour: Literal["error", "continue", "pad_invalids", "retry"] = "retry"
-    max_tokens: int | None = None
+    max_tokens: int | None = None  # For o1 models this is converted to max_completion_tokens in the API layer
+    max_completion_tokens: int | None = None  # Used by o1 models
     logprobs: int | None = None
     seed: int | None = None
     return_logprobs: bool = False  # ?
     top_k_logprobs: int | None = None  # ?
     logit_bias: dict[int, float] | None = None
-
+    response_format: Any = pydantic.Field(
+        default=None,
+        # TODO: Stopgap.
+        # Currently we send a pydantic.BaseModel class type in this param, which is not serializable.
+        # Caching will be agnostic to the value of this field
+        # Remove exlude=True once you figure out how to serialise pydantic.BaseModel class types
+        exclude=True
+    )
     model_config = pydantic.ConfigDict(extra="forbid")
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 """Basic tests for the api."""
 
-import pytest
 import pydantic
+import pytest
 
 from safetytooling.apis.inference.api import InferenceAPI
 from safetytooling.utils import utils

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """Basic tests for the api."""
 
 import pytest
+import pydantic
 
 from safetytooling.apis.inference.api import InferenceAPI
 from safetytooling.utils import utils
@@ -57,3 +58,28 @@ async def test_claude_3_with_system_prompt():
     assert len(resp) == 2
     assert isinstance(resp[0], str)
     assert isinstance(resp[1], str)
+
+
+@pytest.mark.asyncio
+async def test_gpt4o_mini_2024_07_18_with_response_format():
+    utils.setup_environment()
+
+    class CustomResponse(pydantic.BaseModel):
+        answer: str
+        confidence: float
+
+    resp = await InferenceAPI.get_default_global_api().ask_single_question(
+        model_ids="gpt-4o-mini-2024-07-18",
+        question="What is the meaning of life? Format your response as a JSON object with fields: answer (string) and confidence (float between 0 and 1).",
+        max_tokens=100,
+        n=2,
+        response_format=CustomResponse,
+    )
+    assert isinstance(resp, list)
+    assert len(resp) == 2
+    assert isinstance(resp[0], str)
+    assert isinstance(resp[1], str)
+
+    # Verify responses can be parsed into CustomResponse objects
+    CustomResponse.model_validate_json(resp[0])
+    CustomResponse.model_validate_json(resp[1])


### PR DESCRIPTION
1. Added o1-2024-12-17 to the list of models(the older models in the list don't support structured outputs) 
2. Added code to rename max_tokens to max_completion tokens if model belongs to o1 family
3. Added support for [OpenAI Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs#supported-models)
    a) Added response_format in LLMParams(currently ignored for caching/serialisation)
    b) Switched to OpenAI parse instead of completion API if response_format is a subclass of pydantic.BaseModel(OpenAI complains if we send a classtype response_format in the completion API)