### PR TITLE
support multiple completions for VLLM

### DIFF
--- a/safetytooling/apis/inference/runpod_vllm.py
+++ b/safetytooling/apis/inference/runpod_vllm.py
@@ -142,7 +142,7 @@ class VLLMChatModel(InferenceAPIModel):
 
                     if not all(is_valid(choice["message"]["content"]) for choice in response_data["choices"]):
                         LOGGER.error(f"Invalid responses according to is_valid {response_data}")
-                        raise RuntimeError(f"Invalid responses according to is_valid {responses}")
+                        raise RuntimeError(f"Invalid responses according to is_valid {response_data}")
 
             except Exception as e:
                 error_info = f"Exception Type: {type(e).__name__}, Error Details: {str(e)}, Traceback: {format_exc()}"

--- a/safetytooling/apis/inference/runpod_vllm.py
+++ b/safetytooling/apis/inference/runpod_vllm.py
@@ -42,6 +42,7 @@ class VLLMChatModel(InferenceAPIModel):
             "top_p": "top_p",
             "stream": "stream",
             "logprobs": "logprobs",
+            "n": "n",
         }
 
         self.stop_reason_map = {
@@ -139,10 +140,9 @@ class VLLMChatModel(InferenceAPIModel):
                         LOGGER.error(f"Invalid response format: {response_data}")
                         raise RuntimeError(f"Invalid response format: {response_data}")
 
-                    completion = response_data["choices"][0]["message"]["content"]
-                    if not is_valid(completion):
-                        LOGGER.error(f"Invalid response according to is_valid: {completion}")
-                        raise RuntimeError(f"Invalid response according to is_valid: {completion}")
+                    if not all(is_valid(choice["message"]["content"]) for choice in response_data["choices"]):
+                        LOGGER.error(f"Invalid responses according to is_valid {response_data}")
+                        raise RuntimeError(f"Invalid responses according to is_valid {responses}")
 
             except Exception as e:
                 error_info = f"Exception Type: {type(e).__name__}, Error Details: {str(e)}, Traceback: {format_exc()}"

--- a/safetytooling/apis/inference/together.py
+++ b/safetytooling/apis/inference/together.py
@@ -52,18 +52,14 @@ class TogetherChatModel(InferenceAPIModel):
         self.allowed_kwargs = {"temperature", "max_tokens", "logprobs", "n"}
 
     @staticmethod
-    def convert_top_logprobs(data: ChatCompletionResponse) -> list[dict]:
-        # convert OpenAI chat version of logprobs response to completion version
+    def convert_top_logprobs(data) -> list[dict]:
+        # convert TogetherAI chat version of logprobs response to match OpenAI completion version
+        # note that TogetherAI only supports one logprob per token
+
         top_logprobs = []
 
-        for item in data.content:
-            # <|end|> is known to be duplicated on gpt-4-turbo-2024-04-09
-            # See experiments/sample-notebooks/api-tests/logprob-dup-tokens.ipynb for details
-            possibly_duplicated_top_logprobs = collections.defaultdict(list)
-            for top_logprob in item.top_logprobs:
-                possibly_duplicated_top_logprobs[top_logprob.token].append(top_logprob.logprob)
-
-            top_logprobs.append({k: math_utils.logsumexp(vs) for k, vs in possibly_duplicated_top_logprobs.items()})
+        for token, logprob in zip(data.tokens, data.token_logprobs):
+            top_logprobs.append({token: logprob})
 
         return top_logprobs
 

--- a/safetytooling/apis/inference/together.py
+++ b/safetytooling/apis/inference/together.py
@@ -49,7 +49,7 @@ class TogetherChatModel(InferenceAPIModel):
         else:
             self.aclient = None
         self.available_requests = asyncio.BoundedSemaphore(int(self.num_threads))
-        self.allowed_kwargs = {"temperature", "max_tokens", "logprobs"}
+        self.allowed_kwargs = {"temperature", "max_tokens", "logprobs", "n"}
 
     @staticmethod
     def convert_top_logprobs(data: ChatCompletionResponse) -> list[dict]:
@@ -123,7 +123,11 @@ class TogetherChatModel(InferenceAPIModel):
 
         if response_data is None:
             raise RuntimeError("No response data received")
-        assert len(response_data.choices) == 1, f"Expected 1 choice, got {len(response_data.choices)}"
+
+        assert len(response_data.choices) == kwargs.get(
+            "n", 1
+        ), f"Expected {kwargs.get('n', 1)} choices, got {len(response_data.choices)}"
+
         responses = [
             LLMResponse(
                 model_id=model_id,

--- a/safetytooling/apis/inference/together.py
+++ b/safetytooling/apis/inference/together.py
@@ -1,15 +1,12 @@
 import asyncio
-import collections
 import logging
 import time
 from pathlib import Path
 from traceback import format_exc
 
 from together import AsyncTogether
-from together.types import ChatCompletionResponse
 
 from safetytooling.data_models import LLMResponse, Prompt
-from safetytooling.utils import math_utils
 
 from .model import InferenceAPIModel
 


### PR DESCRIPTION


The parameter `n` is [passed to the `VLLMChatModel`'s `__call__` function](https://github.com/safety-research/safety-tooling/blob/b0cc8b9738c58715d4a8b46afdd05e7686a77251/safetytooling/apis/inference/api.py#L549), but it was previously unused.

Within `VLLMChatModel`'s `__call__` function, the [`kwargs` are converted into `params` to be passed to the API](https://github.com/safety-research/safety-tooling/blob/b0cc8b9738c58715d4a8b46afdd05e7686a77251/safetytooling/apis/inference/runpod_vllm.py#L124). In this parsing, `n` was not being copied from `kwargs` to `params`, even though `n` is a valid parameter for the VLLM api.

This is fixed by simply including `n` as a parameter that gets parsed from `kwargs` into `params`. (Unless the intended behavior is for VLLM to be restricted to `n=1`, although in this case we should add an informative error.)