### PR TITLE
non strict models

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ python -m safetytooling.apis.inference.usage.usage_anthropic
         - The cache implementation is automatically selected based on the `REDIS_CACHE` environment variable.
         - **No Cache:** Set `NO_CACHE=True` as an environment variable to disable all caching. This is equivalent to setting `use_cache=False` when initialising an InferenceAPI or BatchInferenceAPI object.
     - **Prompt Logging:** For debugging, human-readable `.txt` files are can be output in `$exp_dir/prompt_history` and timestamped for easy reference (off by default). You can also pass `print_prompt_and_response` to the api object to print coloured messages to the terminal.
-    - Ability to double the rate limit if you pass a list of models e.g. `["gpt-3.5-turbo", "gpt-3.5-turbo-0613"]`
     - Manages rate limits efficiently for OpenAI bypassing the need for exponential backoff.
     - Number of concurrent threads can be customised when initialising the api object for each provider (e.g. `openai_num_threads`, `anthropic_num_threads`). Furthermore, the fraction of the OpenAI rate limit can be specified (e.g. only using 50% rate limit by setting `openai_fraction_rate_limit=0.5`.
     - When initialising the API it checks how much OpenAI rate limit is available and sets caps based on that.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,38 @@ To check for outdated dependencies, run `pip list --outdated`.
 
 ### Running Inference
 
-* See `examples/inference_api/inference_api.ipynb` for an example of how to use the Inference API.
-* See `examples/anthropic_batch_api/run_anthropic_batch.py` for an example of how to use the Anthropic Batch API and how to set up command line input arguments using `simple_parsing` and `ExperimentConfigBase` (a useful base class we created for this project).
+Minimal example to run inference for gpt-4o-mini. See `examples/inference_api/inference_api.ipynb` to quickly run this example.
+
+```
+from safetytooling.apis import InferenceAPI
+from safetytooling.data_models import ChatMessage, MessageRole, Prompt
+from safetytooling.utils import utils
+
+utils.setup_environment()
+API = InferenceAPI(cache_dir=".cache")
+prompt = Prompt(messages=[ChatMessage(content="What is your name?", role=MessageRole.user)])
+
+response = await API(
+    model_id="gpt-4o-mini",
+    prompt=prompt,
+    print_prompt_and_response=True,
+)
+```
+
+The InferenceAPI class supports running new models when they come out without needing to update the codebase. However, you have to pass `force_provider` to the API object call. For example, if you want to run gpt-4-new-model, you can do:
+```
+response = await API(
+    model_id="gpt-4-new-model",
+    prompt=prompt,
+    force_provider="openai"
+)
+```
+Note: setup_environment() will automatically load the API keys and set the environment variables. You can set custom API keys by setting the environment variables instead of calling setup_environment(). If you have multiple API keys for OpenAI and Anthropic, you can pass openai_tag and anthropic_tag to setup_environment() to choose those to be exported.
+```
+utils.setup_environment(openai_tag="OPENAI_API_KEY_CUSTOM", anthropic_tag="ANTHROPIC_API_KEY_CUSTOM")
+```
+
+See `examples/anthropic_batch_api/run_anthropic_batch.py` for an example of how to use the Anthropic Batch API and how to set up command line input arguments using `simple_parsing` and `ExperimentConfigBase` (a useful base class we created for this project).
 
 ### Running Finetuning
 

--- a/examples/anthropic_batch_api/run_anthropic_batch.py
+++ b/examples/anthropic_batch_api/run_anthropic_batch.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 class ExperimentConfig(ExperimentConfigBase):
     """Get responses to requests."""
 
-    model_ids: tuple[str, ...] = ("claude-3-5-sonnet-20241022",)
+    model_id: str = "claude-3-5-sonnet-20241022"
     batch: bool = True
     num_repeats: int = 10
     limit_dataset: int | None = None
@@ -75,11 +75,11 @@ async def main(cfg: ExperimentConfig):
                 batch_dir = output_dir / f"repeat_{repeat}" / f"batch_{i}"
                 batch_dir.mkdir(parents=True, exist_ok=True)
 
-                async def batch_task(model_ids, prompts, batch_dir):
+                async def batch_task(model_id, prompts, batch_dir):
                     batch_start_time = time.time()
                     print(f"Starting batch {batch_dir}")
                     responses, batch_id = await batch_model(
-                        model_ids=model_ids, prompts=prompts, max_tokens=200, log_dir=batch_dir
+                        model_id=model_id, prompts=prompts, max_tokens=200, log_dir=batch_dir
                     )
                     batch_end_time = time.time()
                     batch_duration = batch_end_time - batch_start_time
@@ -98,7 +98,7 @@ async def main(cfg: ExperimentConfig):
                         "num_prompts": len(prompts),
                     }
 
-                batch_tasks.append(batch_task(cfg.model_ids, batch_prompts, batch_dir))
+                batch_tasks.append(batch_task(cfg.model_id, batch_prompts, batch_dir))
 
             batch_results = await asyncio.gather(*batch_tasks)
 
@@ -148,7 +148,7 @@ async def main(cfg: ExperimentConfig):
 
                 batch_start_time = time.time()
                 batch_responses = await asyncio.gather(
-                    *[cfg.api(model_ids=cfg.model_ids, prompt=prompt, max_tokens=200) for prompt in batch_prompts]
+                    *[cfg.api(model_id=cfg.model_id, prompt=prompt, max_tokens=200) for prompt in batch_prompts]
                 )
                 batch_end_time = time.time()
 

--- a/examples/inference_api/inference_api.ipynb
+++ b/examples/inference_api/inference_api.ipynb
@@ -39,7 +39,7 @@
     "prompt = Prompt(messages=[ChatMessage(content=\"What is your name?\", role=MessageRole.user)])\n",
     "\n",
     "response = await API_NO_CACHE(\n",
-    "    model_ids=\"gpt-4o-mini\",\n",
+    "    model_id=\"gpt-4o-mini\",\n",
     "    prompt=prompt,\n",
     "    print_prompt_and_response=True,\n",
     "    max_attempts_per_api_call=1,\n",

--- a/safetytooling/apis/inference/anthropic.py
+++ b/safetytooling/apis/inference/anthropic.py
@@ -95,7 +95,7 @@ class AnthropicChatModel(InferenceAPIModel):
                     api_duration = time.time() - api_start
                     if not is_valid(response):
                         raise RuntimeError(f"Invalid response according to is_valid {response}")
-            except TypeError as e:
+            except (TypeError, anthropic.NotFoundError) as e:
                 raise e
             except Exception as e:
                 error_info = f"Exception Type: {type(e).__name__}, Error Details: {str(e)}, Traceback: {format_exc()}"

--- a/safetytooling/apis/inference/anthropic.py
+++ b/safetytooling/apis/inference/anthropic.py
@@ -53,7 +53,7 @@ class AnthropicChatModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -61,9 +61,6 @@ class AnthropicChatModel(InferenceAPIModel):
         **kwargs,
     ) -> list[LLMResponse]:
         start = time.time()
-        assert len(model_ids) == 1, "Anthropic implementation only supports one model at a time."
-
-        (model_id,) = model_ids
 
         if prompt.contains_image():
             assert model_id in VISION_MODELS, f"Model {model_id} does not support images"
@@ -239,9 +236,7 @@ class AnthropicModelBatch:
         hash_str = prompt.model_hash()
         return f"{index}_{hash_str}"
 
-    def prompts_to_requests(
-        self, model_id: tuple[str, ...], prompts: list[Prompt], max_tokens: int, **kwargs
-    ) -> list[Request]:
+    def prompts_to_requests(self, model_id: str, prompts: list[Prompt], max_tokens: int, **kwargs) -> list[Request]:
         requests = []
         for i, prompt in enumerate(prompts):
             sys_prompt, chat_messages = prompt.anthropic_format()

--- a/safetytooling/apis/inference/deepseek.py
+++ b/safetytooling/apis/inference/deepseek.py
@@ -32,7 +32,7 @@ class DeepSeekChatModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -44,8 +44,6 @@ class DeepSeekChatModel(InferenceAPIModel):
                 "DEEPSEEK_API_KEY environment variable must be set in SECRETS before running your script"
             )
         start = time.time()
-        assert len(model_ids) == 1, "DeepSeek implementation only supports one model at a time."
-        (model_id,) = model_ids
 
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
 

--- a/safetytooling/apis/inference/gemini/genai.py
+++ b/safetytooling/apis/inference/gemini/genai.py
@@ -252,7 +252,7 @@ class GeminiModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -262,8 +262,7 @@ class GeminiModel(InferenceAPIModel):
     ) -> List[LLMResponse]:
         start = time.time()
 
-        for model_id in model_ids:
-            self.add_model_id(model_id)
+        self.add_model_id(model_id)
 
         async def attempt_api_call(model_id):
             async with self.lock:
@@ -289,7 +288,7 @@ class GeminiModel(InferenceAPIModel):
             # Update tracking of recitation retries by generate attempt (not at the prompt level)
             self.total_generate_calls += 1
             try:
-                responses = await attempt_api_call(model_ids[0])
+                responses = await attempt_api_call(model_id)
                 if (
                     responses is not None
                     and len([response for response in responses if is_valid(response)]) / len(responses)
@@ -316,7 +315,7 @@ class GeminiModel(InferenceAPIModel):
             LOGGER.info(f"Current recitation failure rate: {self.recitation_failure_rate* 100:.2f}")
             return [
                 LLMResponse(
-                    model_id=model_ids[0],
+                    model_id=model_id,
                     completion="",
                     stop_reason=GeminiStopReason.RECITATION,
                     safety_ratings={},

--- a/safetytooling/apis/inference/gemini/vertexai.py
+++ b/safetytooling/apis/inference/gemini/vertexai.py
@@ -198,7 +198,7 @@ class GeminiVertexAIModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -208,8 +208,7 @@ class GeminiVertexAIModel(InferenceAPIModel):
     ) -> List[LLMResponse]:
         start = time.time()
 
-        for model_id in model_ids:
-            self.add_model_id(model_id)
+        self.add_model_id(model_id)
 
         async def attempt_api_call(model_id):
             async with self.lock:
@@ -235,7 +234,7 @@ class GeminiVertexAIModel(InferenceAPIModel):
 
         for i in range(max_attempts):
             try:
-                responses = await attempt_api_call(model_ids[0])
+                responses = await attempt_api_call(model_id)
                 if responses is not None and not all(is_valid(response) for response in responses):
                     raise RuntimeError(f"Invalid responses according to is_valid {responses}")
             except (TypeError, InvalidArgument) as e:

--- a/safetytooling/apis/inference/gray_swan.py
+++ b/safetytooling/apis/inference/gray_swan.py
@@ -35,7 +35,7 @@ class GraySwanChatModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -47,8 +47,6 @@ class GraySwanChatModel(InferenceAPIModel):
                 "GRAYSWAN_API_KEY environment variable must be set in SECRETS before running your script"
             )
         start = time.time()
-        assert len(model_ids) == 1, "Cygnet implementation only supports one model at a time."
-        (model_id,) = model_ids
 
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
 

--- a/safetytooling/apis/inference/huggingface.py
+++ b/safetytooling/apis/inference/huggingface.py
@@ -103,7 +103,7 @@ class HuggingFaceModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -113,9 +113,7 @@ class HuggingFaceModel(InferenceAPIModel):
         assert self.token is not None and self.token.startswith("hf_"), f"Invalid token {self.token}"
 
         start = time.time()
-        assert len(model_ids) == 1, "Implementation only supports one model at a time."
 
-        (model_id,) = model_ids
         assert model_id in HUGGINGFACE_MODELS, f"Model {model_id} not supported"
         model_url = HUGGINGFACE_MODELS[model_id]
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)

--- a/safetytooling/apis/inference/huggingface.py
+++ b/safetytooling/apis/inference/huggingface.py
@@ -108,14 +108,18 @@ class HuggingFaceModel(InferenceAPIModel):
         print_prompt_and_response: bool,
         max_attempts: int,
         is_valid=lambda x: True,
+        model_url: str | None = None,
         **kwargs,
     ) -> list[LLMResponse]:
         assert self.token is not None and self.token.startswith("hf_"), f"Invalid token {self.token}"
 
         start = time.time()
 
-        assert model_id in HUGGINGFACE_MODELS, f"Model {model_id} not supported"
-        model_url = HUGGINGFACE_MODELS[model_id]
+        if model_id not in HUGGINGFACE_MODELS:
+            assert model_url is not None, f"Please pass in a model_url for {model_id}"
+        else:
+            model_url = HUGGINGFACE_MODELS[model_id]
+
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
 
         for k, v in self.kwarg_change_name.items():

--- a/safetytooling/apis/inference/model.py
+++ b/safetytooling/apis/inference/model.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 class InferenceAPIModel(Protocol):
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt,
         print_prompt_and_response: bool,
         max_attempts: int,

--- a/safetytooling/apis/inference/openai/base.py
+++ b/safetytooling/apis/inference/openai/base.py
@@ -79,10 +79,6 @@ class OpenAIModel(InferenceAPIModel):
         self.tokenizer = tiktoken.get_encoding("cl100k_base")
 
     @staticmethod
-    def _assert_valid_id(model_id: str):
-        raise NotImplementedError
-
-    @staticmethod
     async def _get_dummy_response_header(model_id: str):
         raise NotImplementedError
 
@@ -101,7 +97,6 @@ class OpenAIModel(InferenceAPIModel):
         return len(self.tokenizer.encode(text))
 
     async def add_model_id(self, model_id: str):
-        self._assert_valid_id(model_id)
         if model_id in self.model_ids:
             return
 
@@ -167,7 +162,7 @@ class OpenAIModel(InferenceAPIModel):
                 responses = await attempt_api_call()
                 if responses is not None and not all(is_valid(response.completion) for response in responses):
                     raise RuntimeError(f"Invalid responses according to is_valid {responses}")
-            except TypeError as e:
+            except (TypeError, openai.NotFoundError) as e:
                 raise e
             except Exception as e:
                 error_info = f"Exception Type: {type(e).__name__}, Error Details: {str(e)}, Traceback: {format_exc()}"

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -14,16 +14,12 @@ from safetytooling.data_models import LLMResponse, Prompt
 from safetytooling.utils import math_utils
 
 from .base import OpenAIModel
-from .utils import GPT_CHAT_MODELS, VISION_MODELS, get_rate_limit, price_per_token
+from .utils import get_rate_limit, price_per_token
 
 LOGGER = logging.getLogger(__name__)
 
 
 class OpenAIChatModel(OpenAIModel):
-    def _assert_valid_id(self, model_id: str):
-        if "ft:" in model_id:
-            model_id = model_id.split(":")[1]
-        assert model_id in GPT_CHAT_MODELS, f"Invalid model id: {model_id}"
 
     @retry(stop=stop_after_attempt(8), wait=wait_fixed(2))
     async def _get_dummy_response_header(self, model_id: str):
@@ -88,9 +84,6 @@ class OpenAIChatModel(OpenAIModel):
 
     async def _make_api_call(self, prompt: Prompt, model_id, start_time, **kwargs) -> list[LLMResponse]:
         LOGGER.debug(f"Making {model_id} call")
-
-        if prompt.contains_image():
-            assert model_id in VISION_MODELS, f"Model {model_id} does not support images"
 
         # convert completion logprobs api to chat logprobs api
         if "logprobs" in kwargs:

--- a/safetytooling/apis/inference/openai/completion.py
+++ b/safetytooling/apis/inference/openai/completion.py
@@ -10,15 +10,12 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 from safetytooling.data_models import LLMResponse, Prompt
 
 from .base import OpenAIModel
-from .utils import COMPLETION_MODELS, get_rate_limit, price_per_token
+from .utils import get_rate_limit, price_per_token
 
 LOGGER = logging.getLogger(__name__)
 
 
 class OpenAICompletionModel(OpenAIModel):
-    def _assert_valid_id(self, model_id: str):
-        assert model_id in COMPLETION_MODELS, f"Invalid model id: {model_id}"
-
     @retry(stop=stop_after_attempt(8), wait=wait_fixed(2))
     async def _get_dummy_response_header(self, model_id: str):
         url = "https://api.openai.com/v1/completions" if self.base_url is None else self.base_url + "/v1/completions"

--- a/safetytooling/apis/inference/openai/s2s.py
+++ b/safetytooling/apis/inference/openai/s2s.py
@@ -187,7 +187,7 @@ class OpenAIS2SModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: str | tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         audio_out_dir: str | Path,
         print_prompt_and_response: bool = False,
@@ -196,10 +196,6 @@ class OpenAIS2SModel(InferenceAPIModel):
     ) -> List[LLMResponse]:
 
         self.max_attempts = max_attempts
-
-        assert len(model_ids) == 1, "Implementation only supports one model at a time."
-
-        (model_id,) = model_ids
 
         start = time.time()
         input_data = prompt.openai_s2s_format()

--- a/safetytooling/apis/inference/openai/s2s.py
+++ b/safetytooling/apis/inference/openai/s2s.py
@@ -195,6 +195,10 @@ class OpenAIS2SModel(InferenceAPIModel):
         **kwargs,
     ) -> List[LLMResponse]:
 
+        assert (
+            model_id == "gpt-4o-realtime-preview-2024-10-01"
+        ), "Only gpt-4o-realtime-preview-2024-10-01 is supported for OpenAI S2S"
+
         self.max_attempts = max_attempts
 
         start = time.time()

--- a/safetytooling/apis/inference/openai/utils.py
+++ b/safetytooling/apis/inference/openai/utils.py
@@ -195,7 +195,7 @@ def get_rate_limit(model_id: str) -> tuple[int, int]:
         case "babbage-002" | "davinci-002" | "text-davinci-003" | "text-davinci-002":
             return 250_000, 3_000
         case _:
-            raise ValueError(f"Invalid model id: {model_id}")
+            return 1_000_000, 10_000  # default to smaller rate limit for unknown models
 
 
 def price_per_token(model_id: str) -> tuple[float, float]:
@@ -270,7 +270,7 @@ def price_per_token(model_id: str) -> tuple[float, float]:
     elif model_id == "gpt-3.5-turbo-instruct" or model_id == "gpt-3.5-turbo-instruct-0914":
         prices = 1.5, 2
     else:
-        raise ValueError(f"Invalid model id: {model_id}")
+        prices = 0, 0  # default to 0 price for unknown models
 
     return tuple(price / 1_000_000 for price in prices)
 
@@ -304,60 +304,3 @@ def finetune_price_per_token(model_id: str) -> float | None:
             return 0.0004
         case _:
             return None
-
-
-def get_equivalent_model_ids(model_id: str) -> tuple[str, ...]:
-    """
-    Updated 2024-04-25 by Tony. This should be periodically updated.
-    """
-
-    # https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#o1
-    o1_models = ("o1", "o1-2024-12-17")
-    if model_id in o1_models:
-        return o1_models
-    o1_mini_models = ("o1-mini", "o1-mini-2024-09-12")
-    if model_id in o1_mini_models:
-        return o1_mini_models
-    o1_preview_models = ("o1-preview", "o1-preview-2024-09-12")
-    if model_id in o1_preview_models:
-        return o1_preview_models
-    o3_mini_models = ("o3-mini", "o3-mini-2025-01-31")
-    if model_id in o3_mini_models:
-        return o3_mini_models
-
-    # https://platform.openai.com/docs/models/gpt-3-5
-    gpt_3_5_turbo_models = ("gpt-3.5-turbo", "gpt-3.5-turbo-0125")
-    if model_id in gpt_3_5_turbo_models:
-        return gpt_3_5_turbo_models
-    gpt_3_5_turbo_16k_models = ("gpt-3.5-turbo-16k", "gpt-3.5-turbo-16k-0613")
-    if model_id in gpt_3_5_turbo_16k_models:
-        return gpt_3_5_turbo_16k_models
-    gpt_3_5_turbo_instruct_models = ("gpt-3.5-turbo-instruct", "gpt-3.5-turbo-instruct-0914")
-    if model_id in gpt_3_5_turbo_instruct_models:
-        return gpt_3_5_turbo_instruct_models
-
-    # https://platform.openai.com/docs/models/gpt-4o
-    gpt_4o_models = ("gpt-4o", "gpt-4o-2024-08-06")
-    if model_id in gpt_4o_models:
-        return gpt_4o_models
-
-    # https://platform.openai.com/docs/models/gpt-4o-mini
-    gpt_4o_mini_models = ("gpt-4o-mini", "gpt-4o-mini-2024-07-18")
-    if model_id in gpt_4o_mini_models:
-        return gpt_4o_mini_models
-
-    # https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
-    gpt_4_models = ("gpt-4", "gpt-4-0613")
-    if model_id in gpt_4_models:
-        return gpt_4_models
-    gpt_4_32k_models = ("gpt-4-32k", "gpt-4-32k-0613")
-    if model_id in gpt_4_32k_models:
-        return gpt_4_32k_models
-    gpt4t_models = ("gpt-4-turbo", "gpt-4-turbo-2024-04-09")
-    if model_id in gpt4t_models:
-        return gpt4t_models
-    gpt4tp_models = ("gpt-4-turbo-preview", "gpt-4-0125-preview")
-    if model_id in gpt4tp_models:
-        return gpt4t_models
-
-    return (model_id,)

--- a/safetytooling/apis/inference/opensource/batch_inference.py
+++ b/safetytooling/apis/inference/opensource/batch_inference.py
@@ -27,7 +27,7 @@ class BatchModel(InferenceAPIModel):
 
     def __call__(
         self,
-        model_ids: str | tuple[str, ...],
+        model_id: str,
         batch_prompt: BatchPrompt,
         print_prompt_and_response: bool,
         max_attempts_per_api_call: int,
@@ -35,9 +35,6 @@ class BatchModel(InferenceAPIModel):
         is_valid: Callable[[str], bool] = lambda _: True,
         **kwargs,
     ) -> list[LLMResponse]:
-        assert len(model_ids) == 1, "Implementation only supports one model at a time."
-        (model_id,) = model_ids
-
         start = time.time()
         batch, text_batch, system_prompts = batch_prompt.batch_format()
 

--- a/safetytooling/apis/inference/runpod_vllm.py
+++ b/safetytooling/apis/inference/runpod_vllm.py
@@ -89,7 +89,7 @@ class VLLMChatModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -97,8 +97,6 @@ class VLLMChatModel(InferenceAPIModel):
         **kwargs,
     ) -> list[LLMResponse]:
         start = time.time()
-        assert len(model_ids) == 1, "VLLM implementation only supports one model at a time."
-        (model_id,) = model_ids
 
         model_url = VLLM_MODELS.get(model_id, self.vllm_base_url)
 

--- a/safetytooling/apis/inference/together.py
+++ b/safetytooling/apis/inference/together.py
@@ -63,7 +63,7 @@ class TogetherChatModel(InferenceAPIModel):
 
     async def __call__(
         self,
-        model_ids: tuple[str, ...],
+        model_id: str,
         prompt: Prompt,
         print_prompt_and_response: bool,
         max_attempts: int,
@@ -75,8 +75,6 @@ class TogetherChatModel(InferenceAPIModel):
                 "TOGETHER_API_KEY environment variable must be set in SECRETS before running your script"
             )
         start = time.time()
-        assert len(model_ids) == 1, "Together implementation only supports one model at a time."
-        (model_id,) = model_ids
 
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
 

--- a/safetytooling/apis/inference/together.py
+++ b/safetytooling/apis/inference/together.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from traceback import format_exc
 
 from together import AsyncTogether
+from together.error import InvalidRequestError
 
 from safetytooling.data_models import LLMResponse, Prompt
 
@@ -100,7 +101,7 @@ class TogetherChatModel(InferenceAPIModel):
                     api_duration = time.time() - api_start
                     if not is_valid(response_data):
                         raise RuntimeError(f"Invalid response according to is_valid {response_data}")
-            except TypeError as e:
+            except (TypeError, InvalidRequestError) as e:
                 raise e
             except Exception as e:
                 error_info = f"Exception Type: {type(e).__name__}, Error Details: {str(e)}, Traceback: {format_exc()}"

--- a/safetytooling/data_models/inference.py
+++ b/safetytooling/data_models/inference.py
@@ -11,7 +11,7 @@ from .hashable import HashableBaseModel
 
 
 class LLMParams(HashableBaseModel):
-    model: str | tuple[str, ...]
+    model: str
     n: int = 1
     num_candidates_per_completion: int = 1
     insufficient_valids_behaviour: Literal["error", "continue", "pad_invalids", "retry"] = "retry"

--- a/safetytooling/data_models/messages.py
+++ b/safetytooling/data_models/messages.py
@@ -236,7 +236,7 @@ class Prompt(HashableBaseModel):
                 return rendered_prompt
 
             case _:
-                raise ValueError(f"Unsupported model {hf_model_id}")
+                return self.openai_format()
 
     def openai_format(
         self,

--- a/safetytooling/utils/jailbreak_metrics.py
+++ b/safetytooling/utils/jailbreak_metrics.py
@@ -42,7 +42,7 @@ class JailbreakMetrics:
 
         try:
             responses = await self.api.__call__(  # TODO: typehints, and return none
-                model_ids=model,
+                model_id=model,
                 n=n_samples,
                 temperature=temperature,
                 prompt=prompt,

--- a/safetytooling/utils/utils.py
+++ b/safetytooling/utils/utils.py
@@ -105,6 +105,7 @@ def setup_logging(logging_level):
     logging.getLogger("git").setLevel(logging.CRITICAL)
     logging.getLogger("httpcore").setLevel(logging.CRITICAL)
     logging.getLogger("anthropic._base_client").setLevel(logging.CRITICAL)
+    logging.getLogger("fork_posix").setLevel(logging.CRITICAL)
 
 
 def load_secrets(local_file_path: str | Path) -> dict[str, str | None]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,7 @@ def test_default_global_api():
 async def test_openai():
     utils.setup_environment()
     resp = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="gpt-4o-mini",
+        model_id="gpt-4o-mini",
         question="What is the meaning of life?",
         max_tokens=1,
         n=2,
@@ -33,7 +33,7 @@ async def test_openai():
 async def test_claude_3():
     utils.setup_environment()
     resp = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="claude-3-haiku-20240307",
+        model_id="claude-3-haiku-20240307",
         question="What is the meaning of life?",
         max_tokens=1,
         n=2,
@@ -48,7 +48,7 @@ async def test_claude_3():
 async def test_claude_3_with_system_prompt():
     utils.setup_environment()
     resp = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="claude-3-haiku-20240307",
+        model_id="claude-3-haiku-20240307",
         question="What is the meaning of life?",
         system_prompt="You are an AI assistant who has never read the Hitchhiker's Guide to the Galaxy.",
         max_tokens=1,
@@ -69,7 +69,7 @@ async def test_gpt4o_mini_2024_07_18_with_response_format():
         confidence: float
 
     resp = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="gpt-4o-mini-2024-07-18",
+        model_id="gpt-4o-mini-2024-07-18",
         question="What is the meaning of life? Format your response as a JSON object with fields: answer (string) and confidence (float between 0 and 1).",
         max_tokens=100,
         n=2,
@@ -92,7 +92,7 @@ async def test_api_with_stop_parameter():
 
     # Test with OpenAI model
     openai_resp = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="gpt-4o-mini-2024-07-18",
+        model_id="gpt-4o-mini-2024-07-18",
         question="Count from 1 to 10: 1, 2, 3,",
         max_tokens=20,
         stop=[", 5"],  # Should stop before outputting ", 5"
@@ -106,7 +106,7 @@ async def test_api_with_stop_parameter():
 
     # Test with Anthropic model
     anthropic_resp = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="claude-3-haiku-20240307",
+        model_id="claude-3-haiku-20240307",
         question="Count from 1 to 10: 1, 2, 3,",
         max_tokens=20,
         stop=[", 5"],  # Should stop before outputting ", 5"

--- a/tests/test_api_cache.py
+++ b/tests/test_api_cache.py
@@ -15,7 +15,7 @@ async def test_api_cache():
 
     q = f"What is the meaning of life? {random.randint(0, 1000000)}"
     response1 = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="gpt-4o-mini-2024-07-18",
+        model_id="gpt-4o-mini-2024-07-18",
         question=q,
         max_tokens=20,
         temperature=1.2,
@@ -24,7 +24,7 @@ async def test_api_cache():
     cost = InferenceAPI.default_global_running_cost()
 
     response2 = await InferenceAPI.get_default_global_api().ask_single_question(
-        model_ids="gpt-4o-mini-2024-07-18",
+        model_id="gpt-4o-mini-2024-07-18",
         question=q,
         max_tokens=20,
         temperature=1.2,
@@ -46,7 +46,7 @@ async def test_no_cache_flag():
     random.seed(time.time())
     q = f"What is the meaning of life? {random.randint(0, 1000000)}"
     _ = await api.ask_single_question(
-        model_ids="gpt-4o-mini-2024-07-18",
+        model_id="gpt-4o-mini-2024-07-18",
         question=q,
         max_tokens=20,
         temperature=1.2,
@@ -55,7 +55,7 @@ async def test_no_cache_flag():
     cost = api.running_cost
 
     _ = await api.ask_single_question(
-        model_ids="gpt-4o-mini-2024-07-18",
+        model_id="gpt-4o-mini-2024-07-18",
         question=q,
         max_tokens=20,
         temperature=1.2,


### PR DESCRIPTION
Add the ability to "force providers" and allow them to try to use unknown models which haven't been added to the known models lists. This means when a new model comes out the repo doesn't have to be updated to use it. Also, I've removed the ability to call a tuple of model_ids from openai. rate limits are so high now this isn't needed and adds complexity which isn't paying rent anymore.


NOTE: Breaking change due to models_id -> model_id to the API!