### PR TITLE
fix bitrot in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ Minimal example to run inference for gpt-4o-mini. See `examples/inference_api/in
 from safetytooling.apis import InferenceAPI
 from safetytooling.data_models import ChatMessage, MessageRole, Prompt
 from safetytooling.utils import utils
+from pathlib import Path
 
 utils.setup_environment()
-API = InferenceAPI(cache_dir=".cache")
+API = InferenceAPI(cache_dir=Path(".cache"))
 prompt = Prompt(messages=[ChatMessage(content="What is your name?", role=MessageRole.user)])
 
 response = await API(

--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ utils.setup_environment(openai_tag="OPENAI_API_KEY_CUSTOM", anthropic_tag="ANTHR
 
 See `examples/anthropic_batch_api/run_anthropic_batch.py` for an example of how to use the Anthropic Batch API and how to set up command line input arguments using `simple_parsing` and `ExperimentConfigBase` (a useful base class we created for this project).
 
+If you want to use a different provider that uses an OpenAI compatible api, you can just override the `base_url` when creating an `InferenceAPI` and then doing `force_provider="openai"` when calling it. E.g.
+```
+API = InferenceAPI(cache_dir=Path(".cache"), openai_base_url="https://openrouter.ai/api/v1", openai_api_key=openrouter_api_key)
+response = await API(
+    model_id="deepseek/deepseek-v3-base:free",
+    prompt=base_prompt,
+    max_tokens=100,
+    print_prompt_and_response=True,
+    temperature=0,
+    force_provider="openai",
+)
+```
+
 ### Running Finetuning
 
 To launch a finetuning job, run the following command:


### PR DESCRIPTION
I got this error without wrapping it in `Path`:

```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[3], line 7
      4 from safetytooling.utils import utils
      6 utils.setup_environment()
----> 7 API = InferenceAPI(cache_dir=".cache")
      8 prompt = Prompt(messages=[ChatMessage(content="What is your name?", role=MessageRole.user)])
     10 response = await API(
     11     model_id="gpt-4o-mini",
     12     prompt=prompt,
     13     print_prompt_and_response=True,
     14 )

File ~/Documents/REDACTED/safety-tooling/safetytooling/apis/inference/api.py:141, in InferenceAPI.__init__(self, anthropic_num_threads, openai_fraction_rate_limit, openai_num_threads, openai_s2s_num_threads, openai_base_url, gpt4o_s2s_rpm_cap, gemini_num_threads, gemini_recitation_rate_check_volume, gemini_recitation_rate_threshold, gray_swan_num_threads, huggingface_num_threads, together_num_threads, vllm_num_threads, deepseek_num_threads, prompt_history_dir, cache_dir, use_redis, empty_completion_threshold, use_gpu_models, anthropic_api_key, openai_api_key, print_prompt_and_response, use_vllm_if_model_not_found, vllm_base_url, no_cache, oai_embedding_batch_size)
    139         self.cache_dir = get_repo_root() / ".cache"
    140 else:
--> 141     assert isinstance(cache_dir, Path) or cache_dir is None
    142     self.cache_dir = cache_dir
    144 self.cache_manager: BaseCacheManager | None = None

AssertionError: 
```