### PR TITLE
OpenRouter integration and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
 # required for together AI API
 TOGETHER_API_KEY=
+# required for openrouter API
+OPENROUTER_API_KEY=
 # required for huggingface inference endpoints
 HF_TOKEN=
 # required for deepseek API

--- a/safetytooling/apis/inference/openrouter.py
+++ b/safetytooling/apis/inference/openrouter.py
@@ -1,0 +1,137 @@
+import asyncio
+import logging
+import time
+from pathlib import Path
+from traceback import format_exc
+
+from openai import AsyncOpenAI, BadRequestError
+
+from safetytooling.data_models import LLMResponse, Prompt
+
+from .model import InferenceAPIModel
+
+OPENROUTER_MODELS = {
+    "x-ai/grok-3-beta",
+    "mistral/ministral-8b",
+    "mistralai/mistral-large-2411",
+}
+LOGGER = logging.getLogger(__name__)
+
+
+class OpenRouterChatModel(InferenceAPIModel):
+    def __init__(
+        self,
+        num_threads: int,
+        prompt_history_dir: Path | None = None,
+        api_key: str | None = None,
+    ):
+        self.num_threads = num_threads
+        self.prompt_history_dir = prompt_history_dir
+        if api_key is not None:
+            self.aclient = AsyncOpenAI(
+                api_key=api_key,
+                base_url="https://openrouter.ai/api/v1",
+            )
+        else:
+            self.aclient = None
+        self.available_requests = asyncio.BoundedSemaphore(int(self.num_threads))
+
+    @staticmethod
+    def convert_top_logprobs(data) -> list[dict]:
+        # convert logprobs response to match OpenAI completion version
+        # OpenRouter uses the same format as OpenAI Chat API
+        top_logprobs = []
+
+        if not hasattr(data, "content") or data.content is None:
+            return []
+
+        for item in data.content:
+            item_logprobs = {}
+            for top_logprob in item.top_logprobs:
+                item_logprobs[top_logprob.token] = top_logprob.logprob
+            top_logprobs.append(item_logprobs)
+
+        return top_logprobs
+
+    async def __call__(
+        self,
+        model_id: str,
+        prompt: Prompt,
+        print_prompt_and_response: bool,
+        max_attempts: int,
+        is_valid=lambda x: True,
+        **kwargs,
+    ) -> list[LLMResponse]:
+
+        if self.aclient is None:
+            raise RuntimeError("OPENROUTER_API_KEY environment variable must be set in .env before running your script")
+        start = time.time()
+
+        prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
+
+        # OpenRouter handles logprobs the same as OpenAI
+        if "logprobs" in kwargs:
+            kwargs["top_logprobs"] = kwargs["logprobs"]
+            kwargs["logprobs"] = True
+
+        LOGGER.debug(f"Making {model_id} call")
+        response_data = None
+        duration = None
+
+        error_list = []
+        for i in range(max_attempts):
+            try:
+                async with self.available_requests:
+                    api_start = time.time()
+
+                    response_data = await self.aclient.chat.completions.create(
+                        messages=prompt.openai_format(),
+                        model=model_id,
+                        **kwargs,
+                    )
+                    api_duration = time.time() - api_start
+                    if not is_valid(response_data):
+                        raise RuntimeError(f"Invalid response according to is_valid {response_data}")
+            except (TypeError, BadRequestError) as e:
+                raise e
+            except Exception as e:
+                error_info = f"Exception Type: {type(e).__name__}, Error Details: {str(e)}, Traceback: {format_exc()}"
+                LOGGER.warn(f"Encountered API error: {error_info}.\nRetrying now. (Attempt {i})")
+                error_list.append(error_info)
+                api_duration = time.time() - api_start
+                await asyncio.sleep(1.5**i)
+            else:
+                break
+
+        duration = time.time() - start
+        LOGGER.debug(f"Completed call to {model_id} in {duration}s")
+
+        if response_data is None:
+            raise RuntimeError("No response data received")
+
+        assert len(response_data.choices) == kwargs.get(
+            "n", 1
+        ), f"Expected {kwargs.get('n', 1)} choices, got {len(response_data.choices)}"
+
+        responses = [
+            LLMResponse(
+                model_id=model_id,
+                completion=choice.message.content,
+                stop_reason=choice.finish_reason,
+                api_duration=api_duration,
+                duration=duration,
+                cost=0,
+                logprobs=(
+                    self.convert_top_logprobs(choice.logprobs)
+                    if hasattr(choice, "logprobs") and choice.logprobs is not None
+                    else None
+                ),
+            )
+            for choice in response_data.choices
+        ]
+
+        self.add_response_to_prompt_file(prompt_file, responses)
+        if print_prompt_and_response:
+            prompt.pretty_print(responses)
+
+        return responses

--- a/tests/test_other_apis.py
+++ b/tests/test_other_apis.py
@@ -1,0 +1,164 @@
+import os
+import random
+import time
+
+import pytest
+from dotenv import load_dotenv
+
+from safetytooling.apis.inference.api import InferenceAPI
+from safetytooling.apis.inference.openrouter import OpenRouterChatModel
+from safetytooling.apis.inference.together import TogetherChatModel
+from safetytooling.data_models import ChatMessage, MessageRole, Prompt
+
+# Load environment variables from .env file
+load_dotenv()
+
+
+# Setup function to create the test prompt
+def create_test_prompt():
+    random.seed(time.time())
+    return Prompt(
+        messages=[
+            ChatMessage(role=MessageRole.system, content="You are a helpful assistant. Time: " + str(time.time())),
+            ChatMessage(role=MessageRole.user, content="What is 2+2? Answer in a single token."),
+        ]
+    )
+
+
+@pytest.mark.skipif("OPENROUTER_API_KEY" not in os.environ, reason="OPENROUTER_API_KEY not available in environment")
+@pytest.mark.asyncio
+async def test_openrouter_init():
+    api = InferenceAPI(
+        openrouter_num_threads=5,
+        together_num_threads=5,
+        prompt_history_dir=None,
+    )
+
+    # Test that OpenRouter provider is properly registered
+    assert "openrouter" in api.provider_to_class
+    assert api.provider_to_class["openrouter"] == api._openrouter
+
+    # Test the model_id_to_class mapping
+    openrouter_model = "mistral/ministral-8b"
+    provider = api.model_id_to_class(openrouter_model)
+    assert isinstance(provider, OpenRouterChatModel)
+
+    # Test force_provider
+    provider_forced = api.model_id_to_class("meta-llama/llama-3-8b-instruct", force_provider="openrouter")
+    assert isinstance(provider_forced, OpenRouterChatModel)
+
+
+@pytest.mark.skipif("TOGETHER_API_KEY" not in os.environ, reason="TOGETHER_API_KEY not available in environment")
+@pytest.mark.asyncio
+async def test_together_init():
+    api = InferenceAPI(
+        openrouter_num_threads=5,
+        together_num_threads=5,
+        prompt_history_dir=None,
+    )
+
+    # Test that Together provider is properly registered
+    assert "together" in api.provider_to_class
+    assert api.provider_to_class["together"] == api._together
+
+    together_model = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
+    provider = api.model_id_to_class(together_model)
+    assert isinstance(provider, TogetherChatModel)
+
+    # Test force_provider
+    provider_forced = api.model_id_to_class("deepseek-ai/DeepSeek-R1", force_provider="together")
+    assert isinstance(provider_forced, TogetherChatModel)
+
+
+@pytest.mark.skipif("OPENROUTER_API_KEY" not in os.environ, reason="OPENROUTER_API_KEY not available in environment")
+@pytest.mark.asyncio
+async def test_openrouter_call():
+    api = InferenceAPI(
+        openrouter_num_threads=5,
+        prompt_history_dir=None,
+    )
+
+    test_prompt = create_test_prompt()
+
+    # Use a simple and inexpensive model for testing
+    model_id = "mistral/ministral-8b"
+
+    # Call the model with force_provider to ensure using OpenRouter
+    responses = await api(
+        model_id=model_id,
+        prompt=test_prompt,
+        print_prompt_and_response=True,
+        force_provider="openrouter",
+        max_tokens=5,
+    )
+
+    # Verify we got a response
+    assert responses is not None
+    assert len(responses) == 1
+    assert isinstance(responses[0].completion, str)
+    assert len(responses[0].completion) > 0
+    assert "4" in responses[0].completion
+
+
+@pytest.mark.skipif("TOGETHER_API_KEY" not in os.environ, reason="TOGETHER_API_KEY not available in environment")
+@pytest.mark.asyncio
+async def test_together_call():
+    api = InferenceAPI(
+        together_num_threads=5,
+        prompt_history_dir=None,
+    )
+
+    test_prompt = create_test_prompt()
+
+    model_id = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
+
+    # Call the model with force_provider to ensure using Together
+    responses = await api(
+        model_id=model_id,
+        prompt=test_prompt,
+        print_prompt_and_response=True,
+        force_provider="together",
+        max_tokens=5,
+    )
+
+    # Verify we got a response
+    assert responses is not None
+    assert len(responses) == 1
+    assert isinstance(responses[0].completion, str)
+    assert len(responses[0].completion) > 0
+    assert "4" in responses[0].completion
+
+
+@pytest.mark.skipif("OPENROUTER_API_KEY" not in os.environ, reason="OPENROUTER_API_KEY not available in environment")
+@pytest.mark.asyncio
+async def test_openrouter_logprobs():
+    api = InferenceAPI(
+        openrouter_num_threads=5,
+        prompt_history_dir=None,
+    )
+
+    test_prompt = create_test_prompt()
+
+    model_id = "openai/gpt-4o-mini-2024-07-18"
+
+    # Call the model with logprobs enabled
+    responses = await api(
+        model_id=model_id,
+        prompt=test_prompt,
+        print_prompt_and_response=True,
+        force_provider="openrouter",
+        max_tokens=5,  # Keep the response short for testing
+        logprobs=5,
+        temperature=0.0,  # Make output deterministic
+    )
+
+    # Verify we got a response with logprobs
+    assert responses is not None
+    assert len(responses) == 1
+    assert isinstance(responses[0].completion, str)
+    assert len(responses[0].completion) > 0
+
+    # We can't guarantee logprobs will be returned as it depends on the model
+    # But we should at least check the test runs without errors
+    assert responses[0].logprobs is not None
+    assert "4" in responses[0].logprobs[0] and responses[0].logprobs[0]["4"] > -0.01


### PR DESCRIPTION
Added a test for Together too.

Note: OpenRouter API params are a leaky abstraction over what the various OpenRouter providers (not to be confused with "provider" as used in this codebase) for open-weight models can support. If you are doing something interesting with e.g. response format or logit bias or whatever, it's impossible to test for this in advance.