### PR TITLE
Bugfix: allow OpenAI completions

### DIFF
--- a/safetytooling/apis/inference/api.py
+++ b/safetytooling/apis/inference/api.py
@@ -560,10 +560,10 @@ class InferenceAPI:
             )
         else:
             # At this point, the request should be for DeepSeek or OpenAI, which use the same API.
-            if not isinstance(model_class, OpenAIChatModel):
+            expected_chat_models = [OpenAIChatModel, OpenAICompletionModel]
+            if not any(isinstance(model_class, model) for model in expected_chat_models):
                 raise RuntimeError(
-                    f"Got unexpected model class: {model_class}."
-                    "Make sure to implement logic to handle __call__ for your custom ChatModel."
+                    f"Got unexpected ChatModel class: {model_class}. Make sure to implement logic to handle InferenceAPI.__call__ for your custom ChatModel. Or, add your ChatModel class to expected_chat_models above."
                 )
             if model_class.base_url == DEEPSEEK_BASE_URL:
                 candidate_responses = []


### PR DESCRIPTION
To improve code robustness, [this PR](https://github.com/safety-research/safety-tooling/pull/80) added an exception that is raised when a ChatModel isn't handled explicitly in `InferenceAPI.__call__`. However, the exception erroneously flagged usage of `OpenAICompletionModel`. This minor change fixes this error and adds a more descriptive error message:
```
Got unexpected ChatModel class: {model_class}. Make sure to implement logic to handle InferenceAPI.__call__ for your custom ChatModel. Or, add your ChatModel class to expected_chat_models above.
```