### PR TITLE
Fix backoff logic in anthropic API retry code

### DIFF
--- a/safetytooling/apis/inference/api.py
+++ b/safetytooling/apis/inference/api.py
@@ -323,9 +323,9 @@ class InferenceAPI:
         avg_rpm = self.n_calls / total_runtime
 
         try:
-            assert avg_rpm <= self.gpt4o_s2s_rpm_cap, (
-                f"Average RPM {avg_rpm} is above rate limit of {self.gpt4o_s2s_rpm_cap}!"
-            )
+            assert (
+                avg_rpm <= self.gpt4o_s2s_rpm_cap
+            ), f"Average RPM {avg_rpm} is above rate limit of {self.gpt4o_s2s_rpm_cap}!"
         except Exception:
             LOGGER.warning(
                 f"Average RPM {avg_rpm} with {self.n_calls} calls made in {total_runtime} minutes is above rate limit of {self.gpt4o_s2s_rpm_cap}! Sleeping for {wait_time} seconds"
@@ -448,9 +448,9 @@ class InferenceAPI:
             if all(cached_results):
                 # Assert there is only one result in cached_result if prompt is a regular Prompt (i.e. not BatchPrompt)
                 if isinstance(prompt, Prompt):
-                    assert len(cached_results) == len(cached_responses) == 1, (
-                        "prompt is not a BatchPrompt but cached results contain more than one entry!"
-                    )
+                    assert (
+                        len(cached_results) == len(cached_responses) == 1
+                    ), "prompt is not a BatchPrompt but cached results contain more than one entry!"
                     return cached_responses[0]
                 else:
                     return cached_responses
@@ -626,9 +626,9 @@ class InferenceAPI:
                 insufficient_valids_behaviour,
             )
         else:
-            assert insufficient_valids_behaviour == "retry", (
-                f"We don't support {insufficient_valids_behaviour} for BatchPrompt"
-            )
+            assert (
+                insufficient_valids_behaviour == "retry"
+            ), f"We don't support {insufficient_valids_behaviour} for BatchPrompt"
             responses = candidate_responses
 
         # update running cost and model timings


### PR DESCRIPTION
As written, this code does not properly implement backoff retry logic when more requests to the client are made than there are num_threads. You can see this in the following example:

* Queue 100 API calls with 10 concurrents (i.e., self.available_threads=10)
* This semaphore locks, so only 10 calls are made
* All 10 of these calls return 529 **and immediately exit the semaphore** before being put to sleep by asyncio
* 10 more calls are made immediately, ignoring the asyncio sleep time
* This repeats, usually leading to no backoff between retries

The new code (which moves the semaphore lock up) fixes this by only allowing num_threads requests to be in the calling and waiting states combined.

I've tested this manually on my local machine, but do not have any unit tests for this.

The `api.py` changes are unrelated to my work - somehow, code got merged that causes the linter to fail on that file, so I fixed it.