### PR TITLE
Log expenditure using model-specific token counts

### DIFF
--- a/safetytooling/apis/inference/openai/base.py
+++ b/safetytooling/apis/inference/openai/base.py
@@ -6,7 +6,6 @@ from traceback import format_exc
 from typing import Optional
 
 import openai
-import tiktoken
 
 from safetytooling.data_models import LLMResponse
 
@@ -76,7 +75,6 @@ class OpenAIModel(InferenceAPIModel):
         self.request_capacity = dict()
         self.lock_add = asyncio.Lock()
         self.lock_consume = asyncio.Lock()
-        self.tokenizer = tiktoken.get_encoding("cl100k_base")
 
     @staticmethod
     async def _get_dummy_response_header(model_id: str):
@@ -92,9 +90,6 @@ class OpenAIModel(InferenceAPIModel):
     @staticmethod
     def _print_prompt_and_response(prompt, responses):
         raise NotImplementedError
-
-    def count_tokens(self, text: str) -> int:
-        return len(self.tokenizer.encode(text))
 
     async def add_model_id(self, model_id: str):
         if model_id in self.model_ids:

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -15,13 +15,12 @@ from safetytooling.data_models import LLMResponse, Prompt
 from safetytooling.utils import math_utils
 
 from .base import OpenAIModel
-from .utils import get_rate_limit, price_per_token
+from .utils import count_tokens, get_rate_limit, price_per_token
 
 LOGGER = logging.getLogger(__name__)
 
 
 class OpenAIChatModel(OpenAIModel):
-
     @retry(stop=stop_after_attempt(8), wait=wait_fixed(2))
     async def _get_dummy_response_header(self, model_id: str):
         url = (
@@ -159,7 +158,7 @@ class OpenAIChatModel(OpenAIModel):
                     stop_reason=choice.finish_reason,
                     api_duration=api_duration,
                     duration=duration,
-                    cost=context_cost + self.count_tokens(choice.message.content) * completion_token_cost,
+                    cost=context_cost + count_tokens(choice.message.content, model_id) * completion_token_cost,
                     logprobs=(self.convert_top_logprobs(choice.logprobs) if choice.logprobs is not None else None),
                 )
             )

--- a/safetytooling/apis/inference/openai/utils.py
+++ b/safetytooling/apis/inference/openai/utils.py
@@ -95,8 +95,13 @@ OAI_FINETUNE_MODELS = (
 S2S_MODELS = "gpt-4o-s2s"
 
 
-def count_tokens(text: str) -> int:
-    return len(tiktoken.get_encoding("cl100k_base").encode(text))
+def count_tokens(text: str, model_id: str) -> int:
+    try:
+        encoding = tiktoken.encoding_for_model(model_id)
+    except KeyError:
+        encoding = tiktoken.get_encoding("o200k_base")
+
+    return len(encoding.encode(text))
 
 
 def get_max_context_length(model_id: str) -> int:
@@ -303,7 +308,7 @@ def finetune_price_per_token(model_id: str) -> float | None:
         return 0.005
     elif "gpt-4o-mini" in model_id:
         return 0.003
-    elif "gpt-4o" in model_id or "gpt-4.1-" in model_id:
+    elif "gpt-4o" in model_id or "gpt-4.1" in model_id:
         return 0.025
     elif "ft:gpt-3.5-turbo" in model_id:
         return 0.008


### PR DESCRIPTION
Removed `OpenAIModel.tokenizer` and moved its `count_tokens()` to `utils`. This is because `OpenAIModel` does not define a unique `model_id`, which is needed to determine the correct `tokenizer`. This change should have no cost, since `tiktoken` already [caches the tokenizer for us](https://github.com/openai/tiktoken/blob/main/tiktoken/registry.py#L63).

Note that we no longer log a warning when `tiktoken` does not recognize the `model_id`, instead silently defaulting to `o200k_base`. Please check that the use of "default_tokenizer" in `_count_prompt_token_capacity` is appropriate, as no `model_id` is available there. Actually I'm not sure `OpenAIModel._count_prompt_token_capacity()` is used anywhere; maybe it can be removed.

A remaining issue is that `text_utils.get_attack_string()` still uses the faulty default tokenizer. Some repos call this function, so I'm not sure what we want to do here.

`python -m pytest -v -s -n 6` results: 10 passed, 10 skipped in 14.53s