### PR TITLE
Minimal edit to enable Deepseek prefilling

### DIFF
--- a/safetytooling/apis/inference/openai/batch_api.py
+++ b/safetytooling/apis/inference/openai/batch_api.py
@@ -123,6 +123,7 @@ class OpenAIModelBatch:
                     api_duration=None,
                     cost=0,
                     batch_custom_id=result["custom_id"],
+                    reasoning_content=choice["message"].get("reasoning_content", None),
                 )
 
         responses = []

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -117,8 +117,14 @@ class OpenAIChatModel(OpenAIModel):
             )
         else:
             api_func = self.aclient.chat.completions.create
+        if model_id in {"deepseek-chat", "deepseek-reasoner"}:
+            if prompt.is_last_message_assistant():
+                self.aclient.base_url = "https://api.deepseek.com/beta"
+            messages = prompt.deepseek_format()
+        else:
+            messages = prompt.openai_format()
         api_response: openai.types.chat.ChatCompletion = await api_func(
-            messages=prompt.openai_format(),
+            messages=messages,
             model=model_id,
             **kwargs,
         )

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -166,6 +166,7 @@ class OpenAIChatModel(OpenAIModel):
                     duration=duration,
                     cost=context_cost + count_tokens(choice.message.content, model_id) * completion_token_cost,
                     logprobs=(self.convert_top_logprobs(choice.logprobs) if choice.logprobs is not None else None),
+                    reasoning_content=choice.message.reasoning_content,
                 )
             )
         self.add_response_to_prompt_file(prompt_file, responses)

--- a/safetytooling/data_models/messages.py
+++ b/safetytooling/data_models/messages.py
@@ -26,6 +26,7 @@ from .inference import LLMResponse
 PRINT_COLORS = {
     "user": "cyan",
     "system": "magenta",
+    "developer": "magenta",
     "assistant": "light_green",
     "audio": "yellow",
     "image": "yellow",
@@ -36,6 +37,7 @@ PRINT_COLORS = {
 class MessageRole(str, Enum):
     user = "user"
     system = "system"
+    developer = "developer"  # A new system message for OpenAI o1 models
     assistant = "assistant"
     audio = "audio"
     image = "image"


### PR DESCRIPTION
## Summary

Reincorporating the edits made in https://github.com/safety-research/safety-tooling/pull/75 to allow prefilling deepseek models.

This was not handled in the latest update and if I were to run a request with a prefilling, the code would throw an error asking to use `is_prefix=True`. Once I set that parameter, the code would ask me to use the beta url.

## Changes Introduced

- `safetytooling/apis/inference/openai/chat.py`
    - If the model is either `deepseek-reasoner` or `deepseek-chat`, use the `prompt.deepseek_format` function to prepare the prompt.
    - If the last message is by the assistant, use deepseek's beta url. (Note that the overriding is very hacky at the moment, I'm open to any suggestions on how to handle this better)