### PR TITLE
changed clone link to HTTPS instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ source $HOME/.local/bin/env
 
 2. Clone the repository and navigate to the directory.
 ```
-git clone git@github.com:safety-research/safety-tooling.git
+git clone https://github.com/safety-research/safety-tooling.git
 cd safety-tooling
 ```
 


### PR DESCRIPTION
The bash command to clone the repo contained the SSH version of the URL, so it required a private key and did not work. I changed it to the HTTPS version, and it works.