### PR TITLE
adding websearch tool use for Openai and Anthropic APIs

### DIFF
--- a/safetytooling/apis/inference/anthropic.py
+++ b/safetytooling/apis/inference/anthropic.py
@@ -150,7 +150,7 @@ class AnthropicChatModel(InferenceAPIModel):
             is_reasoning = response.content[0].type == "thinking"
             # check whether request is for websearch tool
             types = [c.type for c in response.content]
-            is_websearch = "web_search_tool_result" in types 
+            is_websearch = "web_search_tool_result" in types
             assert (
                 is_reasoning or is_websearch or len(response.content) == 1
             ), "Anthropic reasoning models don't support multiple completions"
@@ -167,8 +167,8 @@ class AnthropicChatModel(InferenceAPIModel):
                     cost=0,
                     reasoning_content=response.content[0].thinking,
                 )
-            elif is_websearch: 
-                texts = [c.text for c in response.content if c.type =='text']
+            elif is_websearch:
+                texts = [c.text for c in response.content if c.type == "text"]
                 response = LLMResponse(
                     model_id=model_id,
                     completion="\n".join(texts),

--- a/safetytooling/apis/inference/anthropic.py
+++ b/safetytooling/apis/inference/anthropic.py
@@ -148,8 +148,11 @@ class AnthropicChatModel(InferenceAPIModel):
 
         else:
             is_reasoning = response.content[0].type == "thinking"
+            # check whether request is for websearch tool
+            types = [c.type for c in response.content]
+            is_websearch = "web_search_tool_result" in types 
             assert (
-                is_reasoning or len(response.content) == 1
+                is_reasoning or is_websearch or len(response.content) == 1
             ), "Anthropic reasoning models don't support multiple completions"
 
             if is_reasoning:
@@ -163,6 +166,16 @@ class AnthropicChatModel(InferenceAPIModel):
                     api_duration=api_duration,
                     cost=0,
                     reasoning_content=response.content[0].thinking,
+                )
+            elif is_websearch: 
+                texts = [c.text for c in response.content if c.type =='text']
+                response = LLMResponse(
+                    model_id=model_id,
+                    completion="\n".join(texts),
+                    stop_reason=response.stop_reason,
+                    duration=duration,
+                    api_duration=api_duration,
+                    cost=0,
                 )
             else:
                 response = LLMResponse(

--- a/safetytooling/apis/inference/anthropic.py
+++ b/safetytooling/apis/inference/anthropic.py
@@ -153,7 +153,7 @@ class AnthropicChatModel(InferenceAPIModel):
             is_websearch = "web_search_tool_result" in types
             assert (
                 is_reasoning or is_websearch or len(response.content) == 1
-            ), "Anthropic reasoning models don't support multiple completions"
+            ), "Check that only 1 completion is returned when request is not for websearch tool use or reasoning"
 
             if is_reasoning:
                 if not hasattr(response.content[-1], "text"):

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -102,9 +102,9 @@ class OpenAIChatModel(OpenAIModel):
             kwargs["max_completion_tokens"] = kwargs["max_tokens"]
             del kwargs["max_tokens"]
 
-        if "web_search_options" in kwargs: 
-            assert kwargs['n']==1 
-            del kwargs['n']
+        if "web_search_options" in kwargs:
+            assert kwargs["n"] == 1
+            del kwargs["n"]
 
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
         api_start = time.time()

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -102,6 +102,7 @@ class OpenAIChatModel(OpenAIModel):
             kwargs["max_completion_tokens"] = kwargs["max_tokens"]
             del kwargs["max_tokens"]
 
+        # removing n to not cause an error from OpenAI API when using websearch tool
         if "web_search_options" in kwargs:
             assert kwargs["n"] == 1
             del kwargs["n"]

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -102,6 +102,10 @@ class OpenAIChatModel(OpenAIModel):
             kwargs["max_completion_tokens"] = kwargs["max_tokens"]
             del kwargs["max_tokens"]
 
+        if "web_search_options" in kwargs: 
+            assert kwargs['n']==1 
+            del kwargs['n']
+
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
         api_start = time.time()
 


### PR DESCRIPTION
For OpenAI api, deleted n from kwargs
See documentation here: https://platform.openai.com/docs/guides/tools-web-search?api-mode=chat 

For Anthropic API, added websearch flag, responses for websearch need to be concatenated. 

See documentation here: https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool