### PR TITLE
Certain prompts cause Opus 4 to return empty response due to a refusal classifier

### DIFF
--- a/safetytooling/apis/inference/anthropic.py
+++ b/safetytooling/apis/inference/anthropic.py
@@ -155,13 +155,13 @@ class AnthropicChatModel(InferenceAPIModel):
                 if usage_data
                 else None
             )
-
-            is_reasoning = response.content[0].type == "thinking"
+            # when refusal classifier fires, response.content is []
+            is_reasoning = response.content[0].type == "thinking" if len(response.content) > 0 else False
             # check whether request is for websearch tool
             types = [c.type for c in response.content]
             is_websearch = "web_search_tool_result" in types
             assert (
-                is_reasoning or is_websearch or len(response.content) == 1
+                is_reasoning or is_websearch or len(response.content) <= 1
             ), "Check that only 1 completion is returned when request is not for websearch tool use or reasoning"
 
             if is_reasoning:
@@ -191,7 +191,7 @@ class AnthropicChatModel(InferenceAPIModel):
             else:
                 response = LLMResponse(
                     model_id=model_id,
-                    completion=response.content[0].text,
+                    completion=response.content[0].text if len(response.content) > 0 else "", # refusal classifier, return empty str
                     stop_reason=response.stop_reason,
                     duration=duration,
                     api_duration=api_duration,

--- a/safetytooling/data_models/inference.py
+++ b/safetytooling/data_models/inference.py
@@ -88,7 +88,8 @@ class LLMResponse(pydantic.BaseModel):
         elif v in ["stop", "stop_sequence", "end_turn", "eos"]:
             # end_turn is for Anthropic
             return StopReason.STOP_SEQUENCE
-        elif v in ["content_filter"]:
+        elif v in ["refusal", "content_filter"]:
+            # refusal is for Anthropic
             return StopReason.CONTENT_FILTER
         elif v in ["prompt_blocked"]:
             return StopReason.PROMPT_BLOCKED


### PR DESCRIPTION
This does the minimal changes needed to avoid the error discussed in https://github.com/safety-research/safety-tooling/issues/108