### PR TITLE
feat: add CLAUDE.md boilerplate & lazy-load OpenAI API keys in InferenceAPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,180 @@
+# Claude Code Guide - Safety Tooling
+
+This guide helps Claude Code work effectively with the safety-tooling repository. For general project information, refer to README.md.
+
+## Quick Context
+
+This is an AI safety research toolkit that provides a unified API for multiple LLM providers. The codebase prioritizes stability, caching efficiency, and ease of use across research projects.
+
+## Key Principles When Working on This Codebase
+
+1. **Always preserve backward compatibility** - This is used as a submodule by many projects
+2. **Caching is critical** - Never bypass caching without explicit user request
+3. **API keys are sacred** - Never log or expose API keys, always use the `.env` pattern
+4. **Rate limits matter** - Respect the built-in rate limiting mechanisms
+
+## Common Tasks and Patterns
+
+### Adding Support for a New Model
+
+When a user asks to add support for a new model:
+
+1. **First check if it works with `force_provider`** - Many new models work without code changes:
+   ```python
+   # Try this first before modifying any code
+   response = await API(
+       model_id="new-model-name",
+       prompt=prompt,
+       force_provider="openai"  # or "anthropic" if compatible
+   )
+   ```
+
+2. **Only modify code if force_provider doesn't work** - Look for provider detection logic in the inference API
+
+### Working with Caching
+
+**DO:**
+- Use the existing cache_dir pattern
+- Respect NO_CACHE environment variable
+- Maintain cache key compatibility
+
+**DON'T:**
+- Create new caching mechanisms
+- Modify cache key generation without careful consideration
+- Clear caches without explicit user request
+
+### Handling API Keys
+
+**Pattern to follow:**
+```python
+# Always use utils.setup_environment()
+utils.setup_environment()
+
+# For multiple keys, use the tag system
+utils.setup_environment(
+    openai_tag="OPENAI_API_KEY_PROJECT_X",
+    anthropic_tag="ANTHROPIC_API_KEY_PROJECT_X"
+)
+```
+
+**Never:**
+- Hardcode API keys
+- Create new environment variable patterns
+- Log API keys in any form
+
+### Creating Examples
+
+When writing example code:
+1. Always use async/await patterns (the API is async)
+2. Include proper error handling
+3. Use Path objects for file paths: `Path(".cache")`
+4. Follow the established pattern from existing examples
+
+### Modifying Core Components
+
+**Before modifying any core files, check:**
+- Can this be done with existing extension points?
+- Will this break existing cached responses?
+- Does this maintain backward compatibility?
+
+**Core files to be extra careful with:**
+- `safetytooling/apis/inference/api.py` - The main API
+- `safetytooling/data_models/messages.py` - Data structures
+- Cache-related files - Breaking changes invalidate caches
+
+## Quick Reference
+
+### Standard Inference Pattern
+```python
+from safetytooling.apis import InferenceAPI
+from safetytooling.data_models import ChatMessage, MessageRole, Prompt
+from safetytooling.utils import utils
+from pathlib import Path
+
+# Always start with this
+utils.setup_environment()
+API = InferenceAPI(cache_dir=Path(".cache"))
+
+# Create prompts using the data models
+prompt = Prompt(messages=[
+    ChatMessage(content="Your message", role=MessageRole.user)
+])
+
+# Make API calls
+response = await API(
+    model_id="gpt-4o-mini",
+    prompt=prompt,
+    print_prompt_and_response=True,  # For debugging
+)
+```
+
+### Debugging Issues
+
+1. **Rate limit errors**: Check `openai_fraction_rate_limit` and `num_threads` settings
+2. **Cache misses**: Verify cache_dir path and NO_CACHE environment variable
+3. **API key issues**: Ensure `.env` file exists and `setup_environment()` is called
+4. **Import errors**: User should install with `uv pip install -e .`
+
+### Testing Changes
+
+Always run tests before submitting:
+```bash
+# Quick tests
+python -m pytest -v -s -n 6
+
+# Full test suite (if modifying core functionality)
+SAFETYTOOLING_SLOW_TESTS=True python -m pytest -v -s -n 6
+```
+
+## Important Conventions
+
+### File Organization
+- Examples go in `examples/` with descriptive subdirectories
+- Keep provider-specific code isolated when possible
+- Utilities should be general-purpose and well-tested
+
+### Error Messages
+- Be specific about what went wrong
+- Suggest concrete fixes
+- Point to relevant documentation or examples
+
+### Documentation
+- Update docstrings when modifying functions
+- Add type hints to new code
+- Include usage examples in docstrings for public APIs
+
+## What to Avoid
+
+1. **Breaking changes to Prompt or ChatMessage classes** - These are used everywhere
+2. **Modifying cache key generation** - This invalidates existing caches
+3. **Adding required parameters to existing functions** - Use optional parameters with defaults
+4. **Creating new environment variable patterns** - Use the existing .env system
+5. **Synchronous code in the API path** - Everything should be async
+
+## When Stuck
+
+1. Check existing examples in the `examples/` directory
+2. Look for similar patterns in the codebase
+3. Verify your approach maintains backward compatibility
+4. Consider if the task can be done without modifying core files
+
+## Special Considerations
+
+### Working with Batch APIs
+- Batch processing has separate examples and patterns
+- Don't mix batch and regular inference patterns
+- Respect batch API specific rate limits
+
+### Multi-provider Support
+- Each provider has different message format requirements
+- The Prompt class handles conversion - don't bypass it
+- Test with multiple providers when modifying core functionality
+
+### Redis Caching
+- Redis is optional - code must work with file-based caching too
+- Check REDIS_CACHE environment variable
+- Don't assume Redis is available
+
+## Remember
+
+This codebase is used by multiple AI safety research projects. Stability and reliability are more important than new features. When in doubt, ask the user for clarification rather than making breaking changes.

--- a/safetytooling/apis/inference/openai/base.py
+++ b/safetytooling/apis/inference/openai/base.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import time
 from pathlib import Path
 from traceback import format_exc
@@ -65,16 +66,39 @@ class OpenAIModel(InferenceAPIModel):
         self.prompt_history_dir = prompt_history_dir
         self.model_ids = set()
         self.base_url = base_url
-        if openai_api_key:
-            self.aclient = openai.AsyncClient(api_key=openai_api_key, base_url=self.base_url)
-        else:
-            self.aclient = openai.AsyncClient(base_url=self.base_url)
         self.openai_api_key = openai_api_key
+        self._aclient = None
+        self._client_initialized = False
 
         self.token_capacity = dict()
         self.request_capacity = dict()
         self.lock_add = asyncio.Lock()
         self.lock_consume = asyncio.Lock()
+
+    def _ensure_client(self):
+        """Initialize client when actually calling the request"""
+        if not self._client_initialized:
+            if self.openai_api_key:
+                self._aclient = openai.AsyncClient(api_key=self.openai_api_key, base_url=self.base_url)  # Note: _aclient
+            else:
+                # Try to get from environment
+                if "OPENAI_API_KEY" in os.environ:
+                    self._aclient = openai.AsyncClient(base_url=self.base_url)  # Note: _aclient
+                else:
+                    raise ValueError(
+                        "OpenAI API key is required for this request but not found.\n"
+                        "Please either:\n"
+                        "1. Add OPENAI_API_KEY=<your-key> to your .env file\n"
+                        "2. Pass openai_api_key parameter when creating InferenceAPI\n"
+                        "3. Set the OPENAI_API_KEY environment variable"
+                    )
+            self._client_initialized = True
+
+    @property
+    def aclient(self):
+        """Property to access the client, ensures it's initialized"""
+        self._ensure_client()
+        return self._aclient
 
     @staticmethod
     async def _get_dummy_response_header(model_id: str):
@@ -92,6 +116,8 @@ class OpenAIModel(InferenceAPIModel):
         raise NotImplementedError
 
     async def add_model_id(self, model_id: str):
+        self._ensure_client()
+
         if model_id in self.model_ids:
             return
 

--- a/safetytooling/apis/inference/openai/chat.py
+++ b/safetytooling/apis/inference/openai/chat.py
@@ -23,7 +23,9 @@ LOGGER = logging.getLogger(__name__)
 class OpenAIChatModel(OpenAIModel):
     @retry(stop=stop_after_attempt(8), wait=wait_fixed(2))
     async def _get_dummy_response_header(self, model_id: str):
-        self._ensure_client()
+        if self.aclient is None:
+            raise RuntimeError("OpenAI API key must be set either via parameter or OPENAI_API_KEY environment variable")
+                
         url = (
             "https://api.openai.com/v1/chat/completions"
             if self.base_url is None
@@ -94,10 +96,10 @@ class OpenAIChatModel(OpenAIModel):
         return top_logprobs
 
     async def _make_api_call(self, prompt: Prompt, model_id, start_time, **kwargs) -> list[LLMResponse]:
-        LOGGER.debug(f"Making {model_id} call")
-
-        # ensure api key is set and valid when making the request
-        self._ensure_client()
+        if self.aclient is None:
+            raise RuntimeError("OpenAI API key must be set either via parameter or OPENAI_API_KEY environment variable")
+    
+        LOGGER.debug(f"Making {model_id} call")       
 
         # convert completion logprobs api to chat logprobs api
         if "logprobs" in kwargs:
@@ -203,8 +205,9 @@ class OpenAIChatModel(OpenAIModel):
         model_id,
         **kwargs,
     ) -> openai.AsyncStream[openai.types.chat.ChatCompletionChunk]:
-        # ensure api key is set and valid when making the request
-        self._ensure_client()
+        if self.aclient is None:
+            raise RuntimeError("OpenAI API key must be set either via parameter or OPENAI_API_KEY environment variable")
+
 
         return await self.aclient.chat.completions.create(
             messages=prompt.openai_format(),

--- a/safetytooling/apis/inference/openai/completion.py
+++ b/safetytooling/apis/inference/openai/completion.py
@@ -18,8 +18,8 @@ LOGGER = logging.getLogger(__name__)
 class OpenAICompletionModel(OpenAIModel):
     @retry(stop=stop_after_attempt(8), wait=wait_fixed(2))
     async def _get_dummy_response_header(self, model_id: str):
-        # ensure api key is set and valid when making the request
-        self._ensure_client()
+        if self.aclient is None:
+            raise RuntimeError("OpenAI API key must be set either via parameter or OPENAI_API_KEY environment variable")
 
         url = "https://api.openai.com/v1/completions" if self.base_url is None else self.base_url + "/v1/completions"
         
@@ -56,9 +56,10 @@ class OpenAICompletionModel(OpenAIModel):
         return prompt_tokens + completion_tokens
 
     async def _make_api_call(self, prompt: Prompt, model_id, start_time, **params) -> list[LLMResponse]:
+        if self.aclient is None:
+            raise RuntimeError("OpenAI API key must be set either via parameter or OPENAI_API_KEY environment variable")
+         
         LOGGER.debug(f"Making {model_id} call")
-        # ensure api key is set and valid when making the request
-        self._ensure_client()
 
         prompt_file = self.create_prompt_history_file(prompt, model_id, self.prompt_history_dir)
         api_start = time.time()

--- a/safetytooling/apis/inference/openai/embedding.py
+++ b/safetytooling/apis/inference/openai/embedding.py
@@ -20,8 +20,32 @@ class OpenAIEmbeddingModel:
         self.num_threads = 1
         self.batch_size = batch_size  # Max batch size for embedding endpoint
 
-        self.aclient = openai.AsyncClient()
+        # Lazy initialization
+        self._aclient = None
+        self._client_initialized = False
+
         self.available_requests = asyncio.BoundedSemaphore(self.num_threads)
+
+    def _ensure_client(self):
+        """Initialize client when needed"""
+        if not self._client_initialized:
+            import os
+            if "OPENAI_API_KEY" in os.environ:
+                self._aclient = openai.AsyncClient()
+            else:
+                raise ValueError(
+                    "OpenAI API key is required for moderation but not found.\n"
+                    "Please either:\n"
+                    "1. Add OPENAI_API_KEY=<your-key> to your .env file\n"
+                    "2. Set the OPENAI_API_KEY environment variable"
+                )
+            self._client_initialized = True
+    
+    @property
+    def aclient(self):
+        """Property to access the client, ensures it's initialized"""
+        self._ensure_client()
+        return self._aclient
 
     async def embed(
         self,
@@ -29,6 +53,8 @@ class OpenAIEmbeddingModel:
         max_attempts: int = 5,
         **kwargs,
     ) -> EmbeddingResponseBase64:
+        self._ensure_client()
+        
         assert params.model_id in EMBEDDING_MODELS
 
         if params.dimensions is not None:

--- a/safetytooling/apis/inference/openai/moderation.py
+++ b/safetytooling/apis/inference/openai/moderation.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import time
 from traceback import format_exc
 from typing import Awaitable
@@ -27,32 +28,12 @@ class OpenAIModerationModel:
         self.num_threads = num_threads
         self._batch_size = 32  # Max batch size for moderation endpoint
         
-        # Lazy initialization
-        self._aclient = None
-        self._client_initialized = False
+        if "OPENAI_API_KEY" in os.environ:
+            self.aclient = openai.AsyncClient()
+        else:
+            self.aclient = None
         
         self.available_requests = asyncio.BoundedSemaphore(self.num_threads)
-    
-    def _ensure_client(self):
-        """Initialize client when needed"""
-        if not self._client_initialized:
-            import os
-            if "OPENAI_API_KEY" in os.environ:
-                self._aclient = openai.AsyncClient()
-            else:
-                raise ValueError(
-                    "OpenAI API key is required for moderation but not found.\n"
-                    "Please either:\n"
-                    "1. Add OPENAI_API_KEY=<your-key> to your .env file\n"
-                    "2. Set the OPENAI_API_KEY environment variable"
-                )
-            self._client_initialized = True
-    
-    @property
-    def aclient(self):
-        """Property to access the client, ensures it's initialized"""
-        self._ensure_client()
-        return self._aclient
     
     async def _single_moderation_request(
         self,
@@ -60,8 +41,8 @@ class OpenAIModerationModel:
         texts: list[str],
         max_attempts: int,
     ) -> openai.types.ModerationCreateResponse:
-        # Ensure client is initialized
-        self._ensure_client()
+        if self.aclient is None:
+            raise RuntimeError("OPENAI_API_KEY environment variable must be set to use moderation")
         
         assert len(texts) <= self._batch_size
 

--- a/safetytooling/apis/inference/openai/s2s.py
+++ b/safetytooling/apis/inference/openai/s2s.py
@@ -46,7 +46,8 @@ class S2SRateLimiter:
 
 class OpenAIS2SModel(InferenceAPIModel):
     def __init__(self):
-        self.api_key = os.environ["OPENAI_API_KEY"]
+        # Don't access the API key here - defer it
+        self.api_key = None  # Lazy initialization
         self.base_url = "wss://api.openai.com/v1/realtime"
         self.model = "gpt-4o-realtime-preview-2024-10-01"
         self.max_size = 10 * 1024 * 1024  # 10MB
@@ -55,6 +56,19 @@ class OpenAIS2SModel(InferenceAPIModel):
         self.max_attempts = 10
 
         self.allowed_kwargs = {"temperature", "max_output_tokens", "voice", "audio_format"}
+    
+    def _ensure_api_key(self):
+        """Ensure API key is available when needed"""
+        if self.api_key is None:
+            if "OPENAI_API_KEY" in os.environ:
+                self.api_key = os.environ["OPENAI_API_KEY"]
+            else:
+                raise ValueError(
+                    "OpenAI API key is required for S2S model but not found.\n"
+                    "Please either:\n"
+                    "1. Add OPENAI_API_KEY=<your-key> to your .env file\n"
+                    "2. Set the OPENAI_API_KEY environment variable"
+                )
 
     def log_retry(self, retry_state):
         if retry_state.attempt_number > 1:
@@ -80,6 +94,8 @@ class OpenAIS2SModel(InferenceAPIModel):
         after=log_retry,
     )
     async def connect(self):
+        self._ensure_api_key()
+        
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",

--- a/safetytooling/utils/openai_utils.py
+++ b/safetytooling/utils/openai_utils.py
@@ -77,12 +77,11 @@ def get_top_chat_logprobs(
             max_tokens=1,
             n=1,
             logprobs=True,
-            top_logprobs=5,
+            top_logprobs=n_logprobs,   
             seed=seed,
             stop=[],
             **kwargs,
         )
-
     base_resp = query_api()
 
     # Maps token_idx bytes to (logprob, token_str).
@@ -94,31 +93,5 @@ def get_top_chat_logprobs(
         )
         for top_logprobs in base_resp.choices[0].logprobs.content[0].top_logprobs
     }
-
-    BIAS = -100
-    while len(logprob_dict) < n_logprobs:
-        log_masked_sum = scipy.special.logsumexp([logprob for logprob, _, _ in logprob_dict.values()])
-        unmasked_sum = -scipy.special.expm1(log_masked_sum)
-        log_unmasked_sum = np.log(unmasked_sum)
-
-        resp = query_api(logit_bias={token_idx: BIAS for token_idx in logprob_dict.keys()})
-        for top_logprob in resp.choices[0].logprobs.content[0].top_logprobs:
-            if len(logprob_dict) >= n_logprobs:
-                break
-
-            token_str = top_logprob.token
-            if token_str in ["<|end|>", "<|endoftext|>"]:
-                token_idx = tokenizer.eot_token
-            else:
-                token_idx = tokenizer.encode_single_token(bytes(top_logprob.bytes))
-
-            biased_logprob = top_logprob.logprob
-            true_logprob = biased_logprob + np.logaddexp(log_masked_sum + BIAS, log_unmasked_sum)
-
-            logprob_dict[token_idx] = (
-                true_logprob,
-                token_str,
-                resp.system_fingerprint,
-            )
 
     return logprob_dict


### PR DESCRIPTION
**Description:**
This PR contains two things based on discussions with @jplhughes:

1. **Added `CLAUDE.md` file for Claude Code integration.**
2. **Allow `InferenceAPI` initialization without OpenAI API keys**

   * Modified OpenAI model classes to use lazy API-key validation
   * API keys are now only required when actually making OpenAI calls
   * Follows the same pattern as OpenRouter for consistency
   * Affects: `base.py`, `chat.py`, `completion.py`, `moderation.py`, `embedding.py`, `s2s.py`

This change allows users to instantiate `InferenceAPI` without having OpenAI credentials, enabling them to use other providers (Anthropic, Gemini, etc.) without needing OpenAI API keys in their environment.

**Resolves:**
Missing keys in `.env` should only raise errors when calling the specific provider.
