### PR TITLE
deps: support transformers>=5 (Qwen3.5 multimodal arch compatibility)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "elevenlabs==1.56.0",
     "grayswan-api==0.1.0a49",
     "datasets==3.5.0",
-    "transformers==4.50.3",
+    "transformers>=4.50,<6",
     "wandb==0.19.9",
     "pydub==0.25.1",
     "python-io==0.3",
@@ -48,7 +48,7 @@ dependencies = [
     "pytest==8.3.5",
     "pytest-asyncio==0.26.0",
     "pytest-xdist==3.6.1",
-    "huggingface_hub",
+    "huggingface_hub>=0.33,<2",
     "langchain"
 ]
 

--- a/safetytooling/apis/inference/huggingface.py
+++ b/safetytooling/apis/inference/huggingface.py
@@ -59,7 +59,7 @@ class HuggingFaceModel(InferenceAPIModel):
 
     def count_tokens(self, text, model_name):
         if model_name not in self.tokenizers:
-            self.tokenizers[model_name] = AutoTokenizer.from_pretrained(model_name, use_auth_token=self.token)
+            self.tokenizers[model_name] = AutoTokenizer.from_pretrained(model_name, token=self.token)
         tokenizer = self.tokenizers[model_name]
         return len(tokenizer.tokenize(text))
 


### PR DESCRIPTION
Currently `pyproject.toml` pins `transformers==4.50.3`, which blocks downstream projects that need `transformers>=5` for newer model architectures (e.g. `Qwen3_5ForConditionalGeneration`, the multimodal arch that recent vLLM nightlies also require).

## Scope

- Relax `transformers` pin to `>=4.50,<6` in `pyproject.toml`
- Make the `huggingface_hub` bound explicit (`>=0.33,<2`) so the transformers-5 cascade can't silently downgrade it
- Rename one deprecated kwarg in `safetytooling/apis/inference/huggingface.py` (`AutoTokenizer.from_pretrained(..., use_auth_token=...)` -> `token=...`)

Net diff: 3 insertions, 3 deletions across 2 files.

## Test impact

**0 tests broken.** With `transformers==5.9.0` installed locally, the test suite returns identical pass/skip/fail counts to the 4.50.3 baseline (10 passed / 6 skipped / 7 failed, where the 7 failures are all missing OpenAI/Anthropic API keys, not regressions). Reproduction:

```bash
uv venv --python=python3.11
uv pip install -e .
.venv/bin/python -m pytest --no-header -q \
  --ignore=tests/test_batch_api.py \
  --ignore=tests/test_cloud_run_caching.py \
  --ignore=tests/test_cloud_run_integration.py \
  --ignore=tests/test_vpc_egress.py
```

End-to-end exercise of the one transformers code path (`HuggingFaceModel.count_tokens`) returns the expected token count under transformers 5.9.

## Dependency cascade

`transformers` 5 pulls `huggingface_hub>=1.3,<2`, `tokenizers>=0.22`, `numpy>=2.4`. All resolve cleanly with the existing pyproject; no other version pins need to move.

## Notes

`safetytooling` uses `transformers` in exactly one place (`AutoTokenizer` inside `HuggingFaceModel.count_tokens`), so the surface area touched by this bump is minimal.

There's also a deprecated `env["TRANSFORMERS_CACHE"] = ...` in `safetytooling/utils/vllm_utils.py:259` (the next line already sets `HF_HOME`). Happy to fold that cleanup into this PR if you'd prefer; left it out to keep the diff laser-focused on enabling the bump.